### PR TITLE
Version 1.1.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.ppgome</groupId>
     <artifactId>CritterGuard</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>critterguard</name>

--- a/src/main/java/me/ppgome/critterGuard/CGConfig.java
+++ b/src/main/java/me/ppgome/critterGuard/CGConfig.java
@@ -86,6 +86,7 @@ public class CGConfig {
     public String CLICK_REVOKE_PASSENGER_ACCESS;
     public String CLICK_TAME;
     public String CLICK_UNTAME;
+    public String CLICK_INFO;
     public Component CLICK_TIMEOUT;
 
     //------------------------------------------------------------------------------------------------------------------
@@ -251,6 +252,8 @@ public class CGConfig {
                 + " " + config.getString(clickActionsPath + "toTameToOthers", errorMessage);
         CLICK_UNTAME = PREFIX
                 + " " + config.getString(clickActionsPath + "toUntame", errorMessage);
+        CLICK_INFO = PREFIX
+                + " " + config.getString(clickActionsPath + "toGetInfo", errorMessage);
         CLICK_TIMEOUT = mm.deserialize(PREFIX
                 + " " + config.getString(clickActionsPath + "timeout", errorMessage));
     }

--- a/src/main/java/me/ppgome/critterGuard/CritterCache.java
+++ b/src/main/java/me/ppgome/critterGuard/CritterCache.java
@@ -2,6 +2,7 @@ package me.ppgome.critterGuard;
 
 import me.ppgome.critterGuard.database.MountAccess;
 import me.ppgome.critterGuard.database.SavedMount;
+import me.ppgome.critterGuard.database.SavedPet;
 import org.bukkit.OfflinePlayer;
 
 import java.util.*;
@@ -22,6 +23,12 @@ public class CritterCache {
      * This cache is used to store all SavedMounts for quick retrieval.
      */
     private HashMap<UUID, SavedMount> savedMountsCache = new HashMap<>();
+
+    /**
+     * An in-memory cache of SavedPet UUIDs.
+     * This cache is used to store all SavedPet UUIDs for quick checking.
+     */
+    private Set<UUID> savedPetsCache = new HashSet<>();
 
     /**s
      * An in-memory cache of PlayerMeta objects.
@@ -46,6 +53,12 @@ public class CritterCache {
      * This cache is used to store player UUIDs that are waiting for untame clicks.
      */
     private Set<UUID> untameClickCache = new HashSet<>();
+
+    /**
+     * An in-memory cache of awaiting clicks for info requests.
+     * This cache is used to store player UUIDs that are waiting for info clicks.
+     */
+    private Set<UUID> infoClickCache = new HashSet<>();
 
     //------------------------------------------------------------------------------------------------------------------
 
@@ -87,6 +100,36 @@ public class CritterCache {
      */
     public void removeSavedMount(SavedMount savedMount) {
         savedMountsCache.remove(savedMount.getEntityUuid());
+    }
+
+    // -------- Saved Pet Cache
+
+    /**
+     * Adds a new saved pet's UUID to the cache.
+     *
+     * @param savedPet The pet's UUID being added to the cache
+     */
+    public void addSavedPet(SavedPet savedPet) {
+        savedPetsCache.add(savedPet.getEntityUuid());
+    }
+
+    /**
+     * Checks if an entity's UUID exists in the saved pet cache.
+     *
+     * @param uuid the UUID being checked
+     * @return true if it does, false if not
+     */
+    public boolean isSavedPet(UUID uuid) {
+        return savedPetsCache.contains(uuid);
+    }
+
+    /**
+     * Removes a saved pet's UUID from the cache.
+     *
+     * @param savedPet The saved pet's UUID to be removed
+     */
+    public void removeSavedPet(SavedPet savedPet) {
+        savedPetsCache.remove(savedPet.getEntityUuid());
     }
 
     // -------- Player Meta Cache
@@ -233,6 +276,36 @@ public class CritterCache {
      */
     public void removeAwaitingUntame(UUID playerUuid) {
         untameClickCache.remove(playerUuid);
+    }
+
+    // -------- Info Click Cache
+
+    /**
+     * Adds a player who is going to be clicking an entity to get its info.
+     *
+     * @param playerUuid The UUID of the player who will be clicking
+     */
+    public void addAwaitingInfo(UUID playerUuid) {
+        infoClickCache.add(playerUuid);
+    }
+
+    /**
+     * Checks if there's a record of the specified player who is in the process of getting a critter's info.
+     *
+     * @param playerUuid The UUID of the player being checked for
+     * @return True if they are in the cache, false if not.
+     */
+    public boolean isAwaitingInfo(UUID playerUuid) {
+        return infoClickCache.contains(playerUuid);
+    }
+
+    /**
+     * Removes a record from the cache that matches the specified UUID.
+     *
+     * @param playerUuid the UUID of the player whose record is being removed from the cache
+     */
+    public void removeAwaitingInfo(UUID playerUuid) {
+        infoClickCache.remove(playerUuid);
     }
 
 }

--- a/src/main/java/me/ppgome/critterGuard/CritterGuard.java
+++ b/src/main/java/me/ppgome/critterGuard/CritterGuard.java
@@ -216,6 +216,7 @@ public final class CritterGuard extends JavaPlugin {
                         playerMeta = registerNewPlayer(savedPet.getEntityOwnerUuid());
                         savedPet.setIndex(playerMeta.getOwnedList().size() + 1);
                         playerMeta.addOwnedAnimal(savedPet);
+                        critterCache.addSavedPet(savedPet);
                     }
                     logInfo("Loaded " + savedPets.size() + " saved pets from the database.");
                 }

--- a/src/main/java/me/ppgome/critterGuard/commands/CommandUtils.java
+++ b/src/main/java/me/ppgome/critterGuard/commands/CommandUtils.java
@@ -3,9 +3,15 @@ package me.ppgome.critterGuard.commands;
 import me.ppgome.critterGuard.CritterGuard;
 import me.ppgome.critterGuard.PlayerMeta;
 import me.ppgome.critterGuard.database.SavedAnimal;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 /**
  * A utility that provides static methods for commands.
@@ -18,18 +24,16 @@ public class CommandUtils {
      *
      * @param critterIdentifier The identifier that will be checked against the player's critters
      * @param playerMeta The player's playermeta to fetch their critters
-     * @param plugin The instance of the plugin
      * @return An entity that matches the identifier. Null if none are found
      */
-    public static Entity searchByIdentifier(String critterIdentifier, PlayerMeta playerMeta, CritterGuard plugin) {
+    public static SavedAnimal searchByIdentifier(String critterIdentifier, PlayerMeta playerMeta) {
         // Check if the identifier is numeric (index-based)
         if (critterIdentifier.matches("\\d+")) {
             // If the identifier is numeric, check if it matches the index
             int index = Integer.parseInt(critterIdentifier) - 1; // Convert to zero-based index
             List<SavedAnimal> ownedList = playerMeta.getOwnedList();
             if (index >= 0 && index < ownedList.size()) {
-                SavedAnimal indexedAnimal = ownedList.get(index);
-                return plugin.getServer().getEntity(indexedAnimal.getEntityUuid());
+                return ownedList.get(index);
             }
         }
         // If not numeric, check for UUID or name match
@@ -37,7 +41,7 @@ public class CommandUtils {
             if (savedAnimal.getEntityUuid().toString().toLowerCase().startsWith(critterIdentifier) ||
                     (savedAnimal.getEntityName() != null &&
                             savedAnimal.getEntityName().toLowerCase().startsWith(critterIdentifier))) {
-                return plugin.getServer().getEntity(savedAnimal.getEntityUuid());
+                return savedAnimal;
             }
         }
         return null;

--- a/src/main/java/me/ppgome/critterGuard/commands/CritterCommand.java
+++ b/src/main/java/me/ppgome/critterGuard/commands/CritterCommand.java
@@ -47,6 +47,7 @@ public class CritterCommand implements CommandExecutor, TabCompleter {
         registerSubCommand(new ReloadSubCommand(plugin));
         registerSubCommand(new ToggleNotifsSubCommand(plugin));
         registerSubCommand(new ShowDisguiseSubCommand(plugin));
+        registerSubCommand(new InfoSubCommand(plugin));
     }
 
     //------------------------------------------------------------------------------------------------------------------

--- a/src/main/java/me/ppgome/critterGuard/commands/GPSSubCommand.java
+++ b/src/main/java/me/ppgome/critterGuard/commands/GPSSubCommand.java
@@ -1,16 +1,20 @@
 package me.ppgome.critterGuard.commands;
 
 import io.papermc.paper.entity.LookAnchor;
+import io.papermc.paper.math.Position;
 import me.ppgome.critterGuard.*;
+import me.ppgome.critterGuard.database.SavedAnimal;
 import me.ppgome.critterGuard.utility.MessageUtils;
 import me.ppgome.critterGuard.utility.PlaceholderParser;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * This class represents the command used to give the player the coordinates of a specific one of their critters.
@@ -55,13 +59,16 @@ public class GPSSubCommand implements SubCommandHandler {
         }
 
         // Search for the critter by name, UUID, or index
-        Entity matchedEntity = CommandUtils.searchByIdentifier(critterIdentifier, playerMeta, plugin);
+        SavedAnimal matchedSavedAnimal = CommandUtils.searchByIdentifier(critterIdentifier, playerMeta);
+        Entity matchedEntity = Bukkit.getEntity(matchedSavedAnimal.getEntityUuid());
 
         // If match found, notify the player
         if(matchedEntity != null) {
-            Location location = matchedEntity.getLocation();
-            player.sendMessage(MessageUtils.locationBuilder(location, NamedTextColor.GREEN));
+            player.sendMessage(MessageUtils.locationBuilder(matchedEntity.getLocation(), NamedTextColor.GREEN));
             player.lookAt(matchedEntity, LookAnchor.EYES, LookAnchor.FEET);
+        } else if(matchedSavedAnimal != null) {
+            player.sendMessage(MessageUtils.locationBuilder(matchedSavedAnimal.getLastLocation(), NamedTextColor.GREEN));
+            player.lookAt(Position.block(matchedSavedAnimal.getLastLocation()), LookAnchor.EYES);
         } else {
             player.sendMessage(PlaceholderParser.of(config.GPS_NO_MATCH).identifier(critterIdentifier).parse());
         }

--- a/src/main/java/me/ppgome/critterGuard/commands/InfoSubCommand.java
+++ b/src/main/java/me/ppgome/critterGuard/commands/InfoSubCommand.java
@@ -1,0 +1,94 @@
+package me.ppgome.critterGuard.commands;
+
+import me.ppgome.critterGuard.CGConfig;
+import me.ppgome.critterGuard.CritterCache;
+import me.ppgome.critterGuard.CritterGuard;
+import me.ppgome.critterGuard.utility.MessageUtils;
+import me.ppgome.critterGuard.utility.PlaceholderParser;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.UUID;
+
+public class InfoSubCommand implements SubCommandHandler {
+
+    /**
+     * The instance of the plugin.
+     */
+    private final CritterGuard plugin;
+    /**
+     * The instance of the configuration class.
+     */
+    private CGConfig config;
+    /**
+     * The instance of the plugin's cache.
+     */
+    private CritterCache critterCache;
+
+    /**
+     * Constructor for UntameSubCommand.
+     * Initializes the command with the plugin instance.
+     *
+     * @param plugin The instance of the CritterGuard plugin.
+     */
+    public InfoSubCommand(CritterGuard plugin) {
+        this.plugin = plugin;
+        this.config = plugin.getCGConfig();
+        this.critterCache = plugin.getCritterCache();
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if(!(sender instanceof Player player)) return;
+        UUID senderUuid = player.getUniqueId();
+        critterCache.addAwaitingInfo(senderUuid);
+        player.sendMessage(PlaceholderParser
+                .of(config.CLICK_INFO)
+                .click()
+                .parse());
+
+        // Set timeout
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (critterCache.isAwaitingInfo(senderUuid)) {
+                critterCache.removeAwaitingInfo(senderUuid);
+                if (player.isOnline()) {
+                    player.sendMessage(config.CLICK_TIMEOUT);
+                }
+            }
+        }, 20L * 15L); // 15 seconds timeout
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        return List.of();
+    }
+
+    @Override
+    public String getCommandName() {
+        return "info";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Fetches the owner and stats of a critter.";
+    }
+
+    @Override
+    public Component getUsage() {
+        return MessageUtils.miniMessageDeserialize(plugin.getCGConfig().PREFIX +
+                " <red>Usage: /critter info");
+    }
+
+    @Override
+    public String getPermission() {
+        return "critterguard.info";
+    }
+
+    @Override
+    public int getMinArgs() {
+        return 0;
+    }
+}

--- a/src/main/java/me/ppgome/critterGuard/commands/ListSubCommand.java
+++ b/src/main/java/me/ppgome/critterGuard/commands/ListSubCommand.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -213,15 +214,17 @@ public class ListSubCommand implements SubCommandHandler {
                 .append(Component.text(" ====----", NamedTextColor.GRAY))
                 .appendNewline();
         for (SavedAnimal animal : animalList) {
-            if(Bukkit.getEntity(animal.getEntityUuid()) == null) {
-                tamingHandler.unregisterSavedMount(animal);
-                continue;
-            }
             String Uuid = animal.getEntityUuid().toString().substring(0, 8);
             String name = animal.getEntityName() != null ? animal.getEntityName() : "No name";
             String type = animal.getEntityType();
             String color = animal.getColor() != null ? animal.getColor() : "N/A";
-            Location location = Bukkit.getEntity(animal.getEntityUuid()).getLocation();
+            Location location;
+            Entity entity = Bukkit.getEntity(animal.getEntityUuid());
+            if(entity != null) {
+                location = entity.getLocation();
+            } else {
+                location = animal.getLastLocation();
+            }
             message = message.appendNewline()
                     .append(Component.text("[" + animal.getIndex() + "] ", NamedTextColor.GOLD))
                     .append(Component.text(Uuid + "... ", NamedTextColor.GRAY))

--- a/src/main/java/me/ppgome/critterGuard/database/SavedAnimal.java
+++ b/src/main/java/me/ppgome/critterGuard/database/SavedAnimal.java
@@ -1,6 +1,8 @@
 package me.ppgome.critterGuard.database;
 
 import com.j256.ormlite.field.DatabaseField;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 
 import java.util.UUID;
 
@@ -39,6 +41,30 @@ public class SavedAnimal {
      */
     @DatabaseField
     String color;
+
+    /**
+     * The X value of the critter's last known location.
+     */
+    @DatabaseField
+    double lastSeenX;
+
+    /**
+     * The Y value of the critter's last known location.
+     */
+    @DatabaseField
+    double lastSeenY;
+
+    /**
+     * The Z value of the critter's last known location.
+     */
+    @DatabaseField
+    double lastSeenZ;
+
+    /**
+     * The last world the critter was known to be in.
+     */
+    @DatabaseField
+    String lastSeenWorld;
 
     /**
      * The numeric index of the entity, used for sorting or ordering purposes.
@@ -159,6 +185,26 @@ public class SavedAnimal {
      */
     public void setIndex(int index) {
         this.index = index;
+    }
+
+    /**
+     * Sets the last known location of the critter.
+     *
+     * @param location The last known location of the critter
+     */
+    public void setLastLocation(Location location) {
+        this.lastSeenX = location.x();
+        this.lastSeenY = location.y();
+        this.lastSeenZ = location.z();
+        this.lastSeenWorld = location.getWorld().getName();
+    }
+
+    /**
+     * Returns the last known location of the critter.
+     * @return the last known location of the critter
+     */
+    public Location getLastLocation() {
+        return new Location(Bukkit.getWorld(this.lastSeenWorld), this.lastSeenX, this.lastSeenY, this.lastSeenZ);
     }
 
 }

--- a/src/main/java/me/ppgome/critterGuard/database/SavedPetTable.java
+++ b/src/main/java/me/ppgome/critterGuard/database/SavedPetTable.java
@@ -1,9 +1,13 @@
 package me.ppgome.critterGuard.database;
 
 import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.stmt.QueryBuilder;
 import me.ppgome.critterGuard.CritterGuard;
+import org.bukkit.entity.Entity;
 
+import java.sql.SQLException;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -62,6 +66,25 @@ public class SavedPetTable {
                 return savedPetDao.queryForAll();
             } catch (Exception e) {
                 plugin.logError("Failed to fetch all saved pets\n" + e.getMessage());
+                return null;
+            }
+        });
+    }
+
+    public CompletableFuture<UUID> getOwner(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                QueryBuilder<SavedPet, String> queryBuilder = savedPetDao.queryBuilder();
+                queryBuilder.selectColumns("entityOwnerUuid");
+                queryBuilder.where().eq("entityUuid", uuid);
+
+                SavedPet savedPet = savedPetDao.queryForFirst(queryBuilder.prepare());
+                if(savedPet != null) {
+                    return savedPet.getEntityOwnerUuid();
+                }
+                return null;
+            } catch (Exception e) {
+                plugin.logError("Failed to fetch owner of saved pet " + uuid +"\n" + e.getMessage());
                 return null;
             }
         });

--- a/src/main/java/me/ppgome/critterGuard/disguisesaddles/DisguiseSaddleHandler.java
+++ b/src/main/java/me/ppgome/critterGuard/disguisesaddles/DisguiseSaddleHandler.java
@@ -158,7 +158,8 @@ public class DisguiseSaddleHandler {
      */
     public void refreshSaddleDisguises() {
         for (Player player : Bukkit.getOnlinePlayers()) {
-            if (player.getVehicle() instanceof Entity entity) {
+            Entity entity = player.getVehicle();
+            if (entity instanceof AbstractHorse || entity instanceof HappyGhast) {
                 String disguiseType = getDisguiseFromSaddle(entity);
                 if (disguiseType != null) {
                     applySaddleDisguise(entity, player, disguiseType);

--- a/src/main/java/me/ppgome/critterGuard/utility/CritterTamingHandler.java
+++ b/src/main/java/me/ppgome/critterGuard/utility/CritterTamingHandler.java
@@ -100,19 +100,23 @@ public class CritterTamingHandler {
             case Horse horse:
                 newMount = new SavedMount(entityId, customName, tamerId, tamerName,
                         entityType, horse.getColor().toString(), horse.getStyle().toString());
+                newMount.setLastLocation(entity.getLocation());
                 break;
 
             case Llama llama:
                 newMount = new SavedMount(entityId, customName, tamerId, tamerName,
                         entityType, llama.getColor().toString());
+                newMount.setLastLocation(entity.getLocation());
                 break;
 
             case AbstractHorse ignored:
                 newMount = new SavedMount(entityId, customName, tamerId, tamerName, entityType);
+                newMount.setLastLocation(entity.getLocation());
                 break;
 
             case HappyGhast ignored:
                 newMount = new SavedMount(entityId, customName, tamerId, tamerName, entityType);
+                newMount.setLastLocation(entity.getLocation());
                 break;
 
             default:
@@ -146,14 +150,17 @@ public class CritterTamingHandler {
             case Wolf wolf:
                 savedPet = new SavedPet(entityId, customName, tamerId, tamerName, entityType,
                         wolf.getVariant().getKey().getKey(), wolf.getSoundVariant().getKey().getKey());
+                completePetRegistration(savedPet, entity);
                 break;
             case Cat cat:
                 savedPet = new SavedPet(entityId, customName, tamerId, tamerName,
                         entityType, cat.getCatType().getKey().getKey());
+                completePetRegistration(savedPet, entity);
                 break;
             case Parrot parrot:
                 savedPet = new SavedPet(entityId, customName, tamerId, tamerName,
                         entityType, parrot.getVariant().toString());
+                completePetRegistration(savedPet, entity);
                 break;
             default:
                 return; // Unsupported pet type
@@ -163,6 +170,11 @@ public class CritterTamingHandler {
         if(player.isOnline()) {
             Bukkit.getPlayer(player.getUniqueId()).sendMessage(config.TAMING_TO_THEMSELVES);
         }
+    }
+
+    public void completePetRegistration(SavedPet savedPet, Entity entity) {
+        savedPet.setLastLocation(entity.getLocation());
+        critterCache.addSavedPet(savedPet);
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -176,7 +176,7 @@ messages:
     # When the player exists and has critters but the provided identifier doesn't match any of their critters
     # PLACEHOLDER: <player> is replaced with the username provided by the player
     # PLACEHOLDER: <identifier> is replaced with the identifier provided by the player
-    noMatch: "<red>No critter found matching <yellow><identifier><>/yellow> for player <yellow><player></yellow>.</red>"
+    noMatch: "<red>No critter found matching <yellow><identifier></yellow> for player <yellow><player></yellow>.</red>"
 
   clickActions:
 
@@ -208,6 +208,10 @@ messages:
     # When a player is prompted to click a critter to untame it
     # PLACEHOLDER: <button> is replaced with the name of the button they need to press
     toUntame: "<green>Use <yellow><button></yellow> on a critter to untame it.</green>"
+
+    # When a player is prompted to click a critter to fetch its info
+    # PLACEHOLDER: <button> is replaced with the name of the button they need to press
+    toGetInfo: "<green>Use <yellow><button></yellow> on a critter to learn more about it.</green>"
 
     # When a player takes too long to respond to a click action prompt
     timeout: "<red>Request timed out. Please try again.</red>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,6 +26,8 @@ permissions:
     default: notop
   critterguard.showdisguise:
     default: notop
+  critterguard.info:
+    default: notop
   critterguard.tame:
     default: op
   critterguard.untame:


### PR DESCRIPTION
- `/cg list` re-enabled.
- Fixed critters being unregistered by CritterGuard when their status is pinged and they're in an unloaded chunk.
- Fixed mounts being deleted completely if anyone other than the owner is mounted on it through a restart.
- Fixed `/cg gps` not being able to locate critters in unloaded chunks.
- Attempted a fix at the flaky access issue where access is dropped on restarts.
- ADDED: `/cg info`
    - Will display who the owner of a critter is.
    - If it's a horse or horse-adjacent, it'll display its speed, jump, and health stats.
- ADDED: A little ding when you click on a critter after a click action.